### PR TITLE
feat: create the iam bundle terraform module

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -13,7 +13,7 @@
         - name: HashiCorp - Setup Terraform
           uses: hashicorp/setup-terraform@v2.0.3
 
-        - name: Terraform fmt
+        - name: Terraform Format
           id: fmt
           run: terraform fmt -check
           continue-on-error: true
@@ -25,6 +25,13 @@
         - name: Terraform Validate
           id: validate
           run: terraform validate -no-color
+
+        - name: Setup Operator Environment
+          uses: charmed-kubernetes/actions-operator@main
+          with:
+            juju-channel: 3.1/stable
+            provider: microk8s
+            channel: 1.25-strict/stable
 
         - name: Terraform Plan
           id: plan

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,90 @@
+  name: Pull Request
+
+  on:
+    pull_request:
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+
+        - name: HashiCorp - Setup Terraform
+          uses: hashicorp/setup-terraform@v2.0.3
+
+        - name: Terraform fmt
+          id: fmt
+          run: terraform fmt -check
+          continue-on-error: true
+
+        - name: Terraform Init
+          id: init
+          run: terraform init
+
+        - name: Terraform Validate
+          id: validate
+          run: terraform validate -no-color
+
+        - name: Terraform Plan
+          id: plan
+          run: terraform plan -no-color
+          continue-on-error: true
+
+        - uses: actions/github-script@v6
+          if: github.event_name == 'pull_request'
+          env:
+            PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+              // 1. Retrieve existing bot comments for the PR
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              })
+              const botComment = comments.find(comment => {
+                return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+              })
+
+              // 2. Prepare format of the comment
+              const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+              #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+              #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+              <details><summary>Validation Output</summary>
+
+              \`\`\`\n
+              ${{ steps.validate.outputs.stdout }}
+              \`\`\`
+
+              </details>
+
+              #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+              <details><summary>Show Plan</summary>
+
+              \`\`\`\n
+              ${process.env.PLAN}
+              \`\`\`
+
+              </details>
+
+              *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+
+              // 3. If we have a comment, update it, otherwise create a new one
+              if (botComment) {
+                github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: output
+                })
+              } else {
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: output
+                })
+              }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.3.0
+  hooks:
+    - id: check-added-large-files
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+    - id: detect-private-key
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.81.0
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_tflint
+      args:
+      - --args=--module
+      - --args=--recursive
+    - id: terraform_validate

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,10 @@
+formatter: markdown table
+
+content: |-
+  {{ .Providers }}
+  {{ .Requirements }}
+  {{ .Inputs }}
+  {{ .Outputs }}
+
+sort:
+  enabled: false

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,16 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/juju/juju" {
+  version     = "0.8.0"
+  constraints = "~> 0.8.0"
+  hashes = [
+    "h1:PH6aiIHsrJZRm5TqHVoer+vzwqVuksmkv2JvYJtCGP4=",
+    "zh:351b8195e23c4708d1f9cce742beb3f2d32e05f68751172fffd99f5a7c8fb7df",
+    "zh:3b000d7e532dd7cacb50f4419d861406d246b0f7df9ba6a94a5dbd42fa0a74c3",
+    "zh:9fa363a21d430996bd0ceb6ed7cc053b524c01f47703eee9f7a8518cbdeab4a5",
+    "zh:d7a63953656d11f4f357c5b7a9580bf32adc6910f6477ec32d2b307a11add067",
+    "zh:e4e55f1e3dc54aa4797fd3a440582d1b3677fac112c7f29a2e4d9a388ccb77b1",
+    "zh:e8244ab5a42ba475f9fab5168da218cd58071fed413efe55053b0631796a8726",
+  ]
+}

--- a/.terraformignore
+++ b/.terraformignore
@@ -1,3 +1,4 @@
+### Terraform template
 # Local .terraform directories
 **/.terraform/*
 
@@ -33,6 +34,9 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+# Ignore the lock file
+.terraform.lock.hcl
+
 # User-specific stuff
 .idea
 
@@ -65,3 +69,6 @@ fabric.properties
 
 # macos
 .DS_Store
+
+# Git
+.git/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/identity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to IAM bundle Terraform module
+
+## Development environment
+
+### Prerequisites
+
+Make sure the following software and tools are installed in the development
+environment.
+
+- `microk8s (v1.25.0+)`
+- `juju (3.1.0+)`
+- `terraform (1.5.0+)`
+- [`pre-commit`](https://pre-commit.com/)
+
+## Developing
+
+### Terraform provider
+
+The Terraform module uses the Juju provider to provision Juju resources.
+Please refer to
+the [Juju provider documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for more information.
+
+A Terraform working directory needs to be initialized at the beginning.
+
+```shell
+terraform init
+```
+
+## Testing
+
+Terraform CLI provides various ways to do formatting and validation.
+
+```shell
+# Formats to a canonical format and style
+$ terraform fmt
+
+# Checks syntactical validation
+$ terraform validate
+
+# Preview the changes
+$ terraform plan
+```
+
+An external linter (e.g. [tflint](https://github.com/terraform-linters/tflint))
+also can be installed and used.
+
+This repository also applies [`pre-commit` framework](https://pre-commit.com/)
+to enforce git commit quality check. Various hooks will be run before the commit
+is submitted.
+
+```shell
+# Install pre-commit hooks
+$ pre-commit install
+
+# Run individual hook manually
+$ pre-commit run <hook>
+```
+
+## Documentation
+
+TBD.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# iam-bundle-integration
+# IAM Bundle Terraform Module
+
+This IAM bundle Terraform module aims to deploy
+the [IAM Bundle](https://github.com/canonical/iam-bundle) via Terraform.
+
+## Getting started
+
+### Prerequisites
+
+Make sure the following software and tools are installed and running
+in the local environment.
+
+- `microk8s (v1.25.0+)`
+- `juju (3.1.0+)`
+- `terraform (v1.5.0+)`
+
+### Deploy locally with Terraform
+
+Because the IAM bundle uses an external Idp provider (e.g. Microsoft Azure),
+it needs to provide additional variables for the module to run. More
+information about the Idp provider configuration can be
+found [here](https://github.com/canonical/kratos-external-idp-integrator/blob/main/config.yaml).
+Please create a Terraform variable definition (`.tfvars`) file in the root
+directory as follows.
+
+```shell
+# idp_provider.tfvars
+idp_provider_config = {
+  client_id           = <client id>
+  provider            = <provider name>
+  provider_id         = <provider id>
+  microsoft_tenant_id = <tenant id> # if using Microsoft Azure
+}
+
+idp_provider_credentials = {
+  client_secret = <client secret>
+}
+```
+
+Run the following commands to deploy the IAM bundle.
+
+```shell
+$ terraform init
+$ terraform apply -var-files="./idp_provider.tfvars"
+```
+
+Run `juju switch iam-bundle` to use the created Juju model.
+
+```shell
+# Observe the status of the applications and integrations
+$ juju status --relations
+```
+
+### Deploy to the Canonical Cloud
+
+TBD.
+
+## Contributing
+
+Please refer to the [doc](./CONTRIBUTING.md) to learn how to make code changes.

--- a/applications.tf
+++ b/applications.tf
@@ -1,0 +1,67 @@
+module "postgresql" {
+  source = "./modules/postgresql"
+
+  model = juju_model.iam_bundle.name
+  name  = "postgresql"
+}
+
+module "public_ingress" {
+  source = "./modules/ingress"
+
+  model = juju_model.iam_bundle.name
+  name  = "public-ingress"
+}
+
+module "admin_ingress" {
+  source = "./modules/ingress"
+
+  model = juju_model.iam_bundle.name
+  name  = "admin-ingress"
+}
+
+module "kratos_external_idp_integrator" {
+  source = "./modules/external_idp_integrator"
+
+  model  = juju_model.iam_bundle.name
+  name   = "kratos-external-idp-integrator"
+  config = merge(var.idp_provider_config, var.idp_provider_credentials)
+}
+
+resource "juju_application" "kratos" {
+  model = juju_model.iam_bundle.name
+  name  = "kratos"
+  trust = var.kratos.trust
+  units = var.kratos.units
+
+  charm {
+    name    = "kratos"
+    channel = var.kratos.channel
+    series  = var.kratos.series
+  }
+}
+
+resource "juju_application" "hydra" {
+  model = juju_model.iam_bundle.name
+  name  = "hydra"
+  trust = var.hydra.trust
+  units = var.hydra.units
+
+  charm {
+    name    = "hydra"
+    channel = var.hydra.channel
+    series  = var.hydra.series
+  }
+}
+
+resource "juju_application" "login_ui" {
+  model = juju_model.iam_bundle.name
+  name  = "login-ui"
+  trust = var.login_ui.trust
+  units = var.login_ui.units
+
+  charm {
+    name    = "identity-platform-login-ui-operator"
+    channel = var.login_ui.channel
+    series  = var.login_ui.series
+  }
+}

--- a/integrations.tf
+++ b/integrations.tf
@@ -1,0 +1,90 @@
+locals {
+  integration_mappings = [
+    {
+      provider          = module.postgresql.name
+      provider_endpoint = "database"
+      requirers = [
+        juju_application.kratos.name, juju_application.hydra.name
+      ]
+      requirer_endpoint = "pg-database"
+    },
+    {
+      provider          = module.public_ingress.name
+      provider_endpoint = "ingress"
+      requirers = [
+        juju_application.kratos.name, juju_application.hydra.name
+      ]
+      requirer_endpoint = "public-ingress"
+    },
+    {
+      provider          = module.public_ingress.name
+      provider_endpoint = "ingress"
+      requirers         = [juju_application.login_ui.name]
+      requirer_endpoint = "ingress"
+    },
+    {
+      provider          = module.admin_ingress.name
+      provider_endpoint = "ingress"
+      requirers = [
+        juju_application.kratos.name, juju_application.hydra.name
+      ]
+      requirer_endpoint = "admin-ingress"
+    },
+    {
+      provider          = module.kratos_external_idp_integrator.name
+      provider_endpoint = "kratos-external-idp"
+      requirers         = [juju_application.kratos.name]
+      requirer_endpoint = "kratos-external-idp"
+    },
+    {
+      provider          = juju_application.hydra.name
+      provider_endpoint = "endpoint-info"
+      requirers = [
+        juju_application.kratos.name, juju_application.login_ui.name
+      ]
+      requirer_endpoint = "endpoint-info"
+    },
+    {
+      provider          = juju_application.kratos.name
+      provider_endpoint = "kratos-endpoint-info"
+      requirers         = [juju_application.login_ui.name]
+      requirer_endpoint = "kratos-endpoint-info"
+    },
+    {
+      provider          = juju_application.login_ui.name
+      provider_endpoint = "ui-endpoint-info"
+      requirers = [
+        juju_application.kratos.name, juju_application.hydra.name
+      ]
+      requirer_endpoint = "ui-endpoint-info"
+    },
+  ]
+  integrations = flatten([
+    for mapping in local.integration_mappings : [
+      for requirer in toset(mapping.requirers) : {
+        provider          = mapping.provider
+        provider_endpoint = mapping.provider_endpoint
+        requirer          = requirer
+        requirer_endpoint = mapping.requirer_endpoint
+      }
+    ]
+  ])
+}
+
+resource "juju_integration" "integration" {
+  for_each = {
+    for idx, integration in local.integrations : idx => integration
+  }
+
+  model = juju_model.iam_bundle.name
+
+  application {
+    name     = each.value.provider
+    endpoint = each.value.provider_endpoint
+  }
+
+  application {
+    name     = each.value.requirer
+    endpoint = each.value.requirer_endpoint
+  }
+}

--- a/model.tf
+++ b/model.tf
@@ -1,0 +1,14 @@
+resource "juju_model" "iam_bundle" {
+  name = var.model
+
+  cloud {
+    name   = var.cloud.name
+    region = var.cloud.region
+  }
+
+  config = {
+    logging-config              = "<root>=INFO"
+    no-proxy                    = "jujucharms.com"
+    update-status-hook-interval = "5m"
+  }
+}

--- a/modules/external_idp_integrator/.terraform.lock.hcl
+++ b/modules/external_idp_integrator/.terraform.lock.hcl
@@ -1,0 +1,16 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/juju/juju" {
+  version     = "0.8.0"
+  constraints = "~> 0.8.0"
+  hashes = [
+    "h1:PH6aiIHsrJZRm5TqHVoer+vzwqVuksmkv2JvYJtCGP4=",
+    "zh:351b8195e23c4708d1f9cce742beb3f2d32e05f68751172fffd99f5a7c8fb7df",
+    "zh:3b000d7e532dd7cacb50f4419d861406d246b0f7df9ba6a94a5dbd42fa0a74c3",
+    "zh:9fa363a21d430996bd0ceb6ed7cc053b524c01f47703eee9f7a8518cbdeab4a5",
+    "zh:d7a63953656d11f4f357c5b7a9580bf32adc6910f6477ec32d2b307a11add067",
+    "zh:e4e55f1e3dc54aa4797fd3a440582d1b3677fac112c7f29a2e4d9a388ccb77b1",
+    "zh:e8244ab5a42ba475f9fab5168da218cd58071fed413efe55053b0631796a8726",
+  ]
+}

--- a/modules/external_idp_integrator/main.tf
+++ b/modules/external_idp_integrator/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.8.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}
+
+resource "juju_application" "external_idp_integrator" {
+  model = var.model
+  name  = var.name
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    series  = var.charm.series
+  }
+
+  config = {
+    for k, v in var.config : k => v if v != null
+  }
+}

--- a/modules/external_idp_integrator/outputs.tf
+++ b/modules/external_idp_integrator/outputs.tf
@@ -1,0 +1,4 @@
+output "name" {
+  description = "The name of the Juju application."
+  value       = juju_application.external_idp_integrator.name
+}

--- a/modules/external_idp_integrator/variables.tf
+++ b/modules/external_idp_integrator/variables.tf
@@ -1,0 +1,64 @@
+variable "model" {
+  description = "The name of the Juju model."
+  type        = string
+  default     = "iam-bundle"
+}
+
+variable "name" {
+  description = "The name of the Juju application."
+  type        = string
+  default     = "external-idp-integrator"
+}
+
+variable "units" {
+  description = "The desired Juju unit count to deploy."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units > 0
+    error_message = "The unit count must be a positive integer."
+  }
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    series : string
+  })
+  default = {
+    name    = "kratos-external-idp-integrator"
+    channel = "edge"
+    series  = "jammy"
+  }
+}
+
+variable "config" {
+  description = "The application charm operator configurations."
+  type = object({
+    client_id : string
+    client_secret : string
+    issuer_url : optional(string)
+    provider : string
+    provider_id : string
+    scope : optional(string, "profile email address phone")
+    microsoft_tenant_id : optional(string)
+    apple_team_id : optional(string)
+    apple_private_key_id : optional(string)
+    apple_private_key : optional(string)
+  })
+  default = {
+    client_id     = "client_id"
+    client_secret = "client_secret"
+    provider      = "generic"
+    provider_id   = "provider_id"
+  }
+}

--- a/modules/ingress/.terraform.lock.hcl
+++ b/modules/ingress/.terraform.lock.hcl
@@ -1,0 +1,16 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/juju/juju" {
+  version     = "0.8.0"
+  constraints = "~> 0.8.0"
+  hashes = [
+    "h1:PH6aiIHsrJZRm5TqHVoer+vzwqVuksmkv2JvYJtCGP4=",
+    "zh:351b8195e23c4708d1f9cce742beb3f2d32e05f68751172fffd99f5a7c8fb7df",
+    "zh:3b000d7e532dd7cacb50f4419d861406d246b0f7df9ba6a94a5dbd42fa0a74c3",
+    "zh:9fa363a21d430996bd0ceb6ed7cc053b524c01f47703eee9f7a8518cbdeab4a5",
+    "zh:d7a63953656d11f4f357c5b7a9580bf32adc6910f6477ec32d2b307a11add067",
+    "zh:e4e55f1e3dc54aa4797fd3a440582d1b3677fac112c7f29a2e4d9a388ccb77b1",
+    "zh:e8244ab5a42ba475f9fab5168da218cd58071fed413efe55053b0631796a8726",
+  ]
+}

--- a/modules/ingress/main.tf
+++ b/modules/ingress/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.8.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}
+
+resource "juju_application" "ingress" {
+  model = var.model
+  name  = var.name
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    series  = var.charm.series
+  }
+}

--- a/modules/ingress/outputs.tf
+++ b/modules/ingress/outputs.tf
@@ -1,0 +1,4 @@
+output "name" {
+  description = "The name of the Juju application."
+  value       = juju_application.ingress.name
+}

--- a/modules/ingress/variables.tf
+++ b/modules/ingress/variables.tf
@@ -1,0 +1,42 @@
+variable "model" {
+  description = "The name of the Juju model."
+  type        = string
+  default     = "iam-bundle"
+}
+
+variable "name" {
+  description = "The name of the Juju application."
+  type        = string
+  default     = "ingress"
+}
+
+variable "units" {
+  description = "The desired Juju unit count to deploy."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units > 0
+    error_message = "The unit count must be a positive integer."
+  }
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    series : string
+  })
+  default = {
+    name    = "traefik-k8s"
+    channel = "edge"
+    series  = "focal"
+  }
+}

--- a/modules/postgresql/.terraform.lock.hcl
+++ b/modules/postgresql/.terraform.lock.hcl
@@ -1,0 +1,16 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/juju/juju" {
+  version     = "0.8.0"
+  constraints = "~> 0.8.0"
+  hashes = [
+    "h1:PH6aiIHsrJZRm5TqHVoer+vzwqVuksmkv2JvYJtCGP4=",
+    "zh:351b8195e23c4708d1f9cce742beb3f2d32e05f68751172fffd99f5a7c8fb7df",
+    "zh:3b000d7e532dd7cacb50f4419d861406d246b0f7df9ba6a94a5dbd42fa0a74c3",
+    "zh:9fa363a21d430996bd0ceb6ed7cc053b524c01f47703eee9f7a8518cbdeab4a5",
+    "zh:d7a63953656d11f4f357c5b7a9580bf32adc6910f6477ec32d2b307a11add067",
+    "zh:e4e55f1e3dc54aa4797fd3a440582d1b3677fac112c7f29a2e4d9a388ccb77b1",
+    "zh:e8244ab5a42ba475f9fab5168da218cd58071fed413efe55053b0631796a8726",
+  ]
+}

--- a/modules/postgresql/main.tf
+++ b/modules/postgresql/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.8.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}
+
+resource "juju_application" "postgresql" {
+  model = var.model
+  name  = var.name
+  trust = var.trust
+  units = var.units
+
+  charm {
+    name    = var.charm.name
+    channel = var.charm.channel
+    series  = var.charm.series
+  }
+}

--- a/modules/postgresql/outputs.tf
+++ b/modules/postgresql/outputs.tf
@@ -1,0 +1,4 @@
+output "name" {
+  description = "The name of the Juju application."
+  value       = juju_application.postgresql.name
+}

--- a/modules/postgresql/variables.tf
+++ b/modules/postgresql/variables.tf
@@ -1,0 +1,42 @@
+variable "model" {
+  description = "The name of the Juju model."
+  type        = string
+  default     = "iam-bundle"
+}
+
+variable "name" {
+  description = "The name of the Juju application."
+  type        = string
+  default     = "postgresql"
+}
+
+variable "units" {
+  description = "The desired Juju unit count to deploy."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.units > 0
+    error_message = "The unit count must be a positive integer."
+  }
+}
+
+variable "trust" {
+  description = "The status to grant the Juju application full access to the cluster."
+  type        = bool
+  default     = true
+}
+
+variable "charm" {
+  description = "The application charm operator information."
+  type = object({
+    name : string
+    channel : string
+    series : string
+  })
+  default = {
+    name    = "postgresql-k8s"
+    channel = "14/stable"
+    series  = "jammy"
+  }
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.8.0"
+    }
+  }
+
+  required_version = ">= 1.5.0"
+}
+
+provider "juju" {}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,84 @@
+variable "model" {
+  description = "The name of the Juju model to deploy to."
+  type        = string
+  default     = "iam-bundle"
+}
+
+variable "cloud" {
+  description = "The Juju cloud information."
+  type = object({
+    name   = string
+    region = string
+  })
+  default = {
+    name   = "microk8s"
+    region = "localhost"
+  }
+}
+
+variable "hydra" {
+  description = "The configurations of the Hydra application."
+  type = object({
+    units   = optional(number, 1)
+    channel = optional(string, "edge")
+    series  = optional(string, "jammy")
+    trust   = optional(string, true)
+    config  = optional(map(string), {})
+  })
+  default = {}
+}
+
+variable "kratos" {
+  description = "The configurations of the Kratos application."
+  type = object({
+    units   = optional(number, 1)
+    channel = optional(string, "edge")
+    series  = optional(string, "jammy")
+    trust   = optional(string, true)
+    config  = optional(map(string), {})
+  })
+  default = {}
+}
+
+variable "login_ui" {
+  description = "The configurations of the Identity Platform Login UI application."
+  type = object({
+    units   = optional(number, 1)
+    trust   = optional(bool, true)
+    config  = optional(map(string), {})
+    channel = optional(string, "edge")
+    series  = optional(string, "jammy")
+  })
+  default = {}
+}
+
+variable "idp_provider_config" {
+  description = "The external Idp provider configurations."
+  type = object({
+    client_id : string
+    issuer_url : optional(string)
+    provider : string
+    provider_id : string
+    scope : optional(string, "profile email address phone")
+    microsoft_tenant_id : optional(string)
+    apple_team_id : optional(string)
+    apple_private_key_id : optional(string)
+  })
+  default = {
+    client_id   = "client_id"
+    provider    = "generic"
+    provider_id = "provider_id"
+  }
+}
+
+variable "idp_provider_credentials" {
+  description = "The external Idp provider credentials."
+  type = object({
+    client_secret : string
+    apple_private_key : optional(string)
+  })
+  default = {
+    client_secret = "client_secret"
+  }
+  sensitive = true
+}


### PR DESCRIPTION
### Context

This PR aims to use Terraform to provision all of the resources in the IAM bundle in order to let other teams easily do integration tests with the bundle.

### Note

This PR is currently working in progress. Feel free to leave comments or suggestions.

### TODO

- [x] Fix `terraform plan` step in the Github action
- [ ] Canonical Cloud access and deployment
- [ ] Documentation update
- [ ] `terraform-doc` Github action (optional, maybe in future PR)
- [ ] Makefile (optional, maybe in future PR)