### PR TITLE
ci: use custom token instead of Github token to have the permission to trigger another action workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,3 +19,4 @@ jobs:
           release-type: terraform-module
           default-branch: main
           pull-request-title-pattern: "ci: release ${version}"
+          token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
Due to the [limits](https://github.com/google-github-actions/release-please-action#github-credentials) of the default `secretes.GITHUB_TOKEN`, it's better to provide a custom token that has the right permissions to trigger another workflow for the PR created by the `google-release-please` action. This is from the workaround: https://github.com/googleapis/release-please/issues/922#issuecomment-861154425