### PR TITLE
chore: bump `self-signed-certificates`, `traefik` in `examples/tutorial`

### DIFF
--- a/examples/tutorial/variables.tf
+++ b/examples/tutorial/variables.tf
@@ -105,8 +105,8 @@ variable "certificates" {
     units   = optional(number, 1)
     trust   = optional(bool, true)
     config  = optional(map(string), {})
-    channel = optional(string, "latest/stable")
-    base    = optional(string, "ubuntu@22.04")
+    channel = optional(string, "1/stable")
+    base    = optional(string, "ubuntu@24.04")
   })
   default = {}
 }
@@ -117,7 +117,9 @@ variable "traefik" {
     units   = optional(number, 1)
     trust   = optional(bool, true)
     config  = optional(map(string), {})
-    channel = optional(string, "latest/stable")
+    # TODO: Pin Traefik to latest/stable after rev>=242 is released to stable.
+    # This fixes an incompatibility between Traefik and some self-signed-certificates releases
+    channel = optional(string, "latest/edge")
     base    = optional(string, "ubuntu@20.04")
   })
   default = {}


### PR DESCRIPTION
* Bump the track of self-signed-certificates deployed by the `examples/tutorial` to `1`.  
* Bump the Traefik deployed by the `examples/tutorial` to `latest/edge` to work with the updated self-signed-certificates

Closes https://github.com/canonical/iam-bundle-integration/issues/66