### PR TITLE
chore: update the channel for kratos_external_idp_integrator to latest/edge

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -32,7 +32,7 @@
         - name: Setup Operator Environment
           uses: charmed-kubernetes/actions-operator@main
           with:
-            juju-channel: 3.1/stable
+            juju-channel: 3/stable
             provider: microk8s
             channel: 1.25-strict/stable
 

--- a/examples/tutorial/variables.tf
+++ b/examples/tutorial/variables.tf
@@ -8,7 +8,7 @@ variable "kratos_external_idp_integrator" {
   description = "The configurations of the Kratos External IdP Integrator application."
   type = object({
     units   = optional(number, 1)
-    channel = optional(string, "latest/stable")
+    channel = optional(string, "latest/edge")
     base    = optional(string, "ubuntu@22.04")
     trust   = optional(string, true)
     config = optional(object({


### PR DESCRIPTION
kratos-external-idp-integrator is configured with incorrect channel.

latest/stable channel doesn’t exist yet.