### PR TITLE
Make send_ca_certificate_offer_url optional

### DIFF
--- a/integrations.tf
+++ b/integrations.tf
@@ -7,6 +7,8 @@ data "juju_offer" "traefik_route" {
 }
 
 data "juju_offer" "ca_certificate" {
+  count = var.send_ca_certificate_offer_url != null ? 1 : 0
+
   url = var.send_ca_certificate_offer_url
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "postgresql_offer_url" {
 variable "send_ca_certificate_offer_url" {
   description = "Send CA Certificate Offer URL"
   type        = string
-  default     = "admin/core.send-ca-cert"
+  default     = null
 }
 
 variable "metrics_offer_url" {


### PR DESCRIPTION
Make this variable optional, as it is not used anywhere in the module